### PR TITLE
chore: add aws account

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,9 @@ inputs:
   application:
     description: 'Application name'
     required: true
+  awsAccount:
+    description: 'AWS Account ID'
+    required: true
 
 runs:
   using: node20

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,12 +9,14 @@ export async function run(): Promise<void> {
   const environment = getInput('environment')
   const application = getInput('application')
   const infrastructure = getInput('infrastructure')
+  const awsAccount = getInput('awsAccount')
   const payload = {
     application,
     infrastructure,
-    creator
+    creator,
+    awsAccount
   }
-  const description = `Deploy: ${application} ${ref} ${environment} ${infrastructure}`
+  const description = `Deploy: ${application} ${ref} ${environment} ${infrastructure} ${awsAccount}`
 
   const appId = getInput('appId')
   const installationId = getInput('installationId') || ''
@@ -39,6 +41,7 @@ export async function run(): Promise<void> {
     description: description,
     payload,
     auto_merge: false,
+    auto_inactive: false,
     required_contexts: []
   })
   console.log(description)


### PR DESCRIPTION
This pull request includes changes to add support for specifying the AWS Account ID in the deployment process. The most important changes include updating the `action.yml` file to accept the new input and modifying the main function to handle this input.

### Input handling improvements:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R19-R21): Added `awsAccount` as a required input parameter.

### Deployment process updates:

* [`src/main.ts`](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR12-R19): Updated the `run` function to retrieve the `awsAccount` input and include it in the deployment payload and description.
* [`src/main.ts`](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR44): Added the `auto_inactive` parameter to the deployment options.