### PR TITLE
Add useLatestTemplate option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,8 +19,8 @@ inputs:
   awsAccount:
     description: 'AWS Account ID'
     required: true
-  useLatestTemplate:
-    description: 'Use the latest template configuration'
+  useLatestManifest:
+    description: 'Use the latest manifest configuration'
     required: false
     default: 'false'
 

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
   awsAccount:
     description: 'AWS Account ID'
     required: true
+  useLatestTemplate:
+    description: 'Use the latest template configuration'
+    required: false
+    default: 'false'
 
 runs:
   using: node20

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     description: 'AWS Account ID'
     required: true
   useLatestManifest:
-    description: 'Use the latest manifest configuration'
+    description: 'Use latest manifest'
     required: false
-    default: 'true'
+    default: 'false'
 
 runs:
   using: node20

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
   useLatestManifest:
     description: 'Use the latest manifest configuration'
     required: false
-    default: 'false'
+    default: 'true'
 
 runs:
   using: node20

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,11 +10,13 @@ export async function run(): Promise<void> {
   const application = getInput('application')
   const infrastructure = getInput('infrastructure')
   const awsAccount = getInput('awsAccount')
+  const useLatestTemplate = getInput('useLatestTemplate')
   const payload = {
     application,
     infrastructure,
     creator,
-    awsAccount
+    awsAccount,
+    useLatestTemplate
   }
   const description = `Deploy: ${application} ${ref} ${environment} ${infrastructure} ${awsAccount}`
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,13 +10,13 @@ export async function run(): Promise<void> {
   const application = getInput('application')
   const infrastructure = getInput('infrastructure')
   const awsAccount = getInput('awsAccount')
-  const useLatestTemplate = getInput('useLatestTemplate')
+  const useLatestManifest = getInput('useLatestManifest')
   const payload = {
     application,
     infrastructure,
     creator,
     awsAccount,
-    useLatestTemplate
+    useLatestManifest
   }
   const description = `Deploy: ${application} ${ref} ${environment} ${infrastructure} ${awsAccount}`
 


### PR DESCRIPTION
This pull request introduces a new input parameter to the GitHub Action configuration and updates the main script to handle this new parameter. The most important changes are:

Enhancements to GitHub Action configuration:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R22-R25): Added a new optional input parameter `useLatestTemplate` with a default value of 'false'.

Updates to the main script:

* [`src/main.ts`](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR13-R19): Modified the `run` function to retrieve the new `useLatestTemplate` input and include it in the payload.